### PR TITLE
Gh004/avatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # IMPORTANT! PLEASE READ... 
 
-The second part of the test states that a message's author's email should be shown when the user hovers their mouse over a message. However, this code is for an iOS app, which has no concept of a mouse! So I've had to improvise, and I've used React Native's touch API instead. So instead of hovering over a message to see the email, simply touch on the message (either with a mouse click if it's on the simulator, or with a finger if it's on an iPhone) instead, and you'll see the email appear.
+## Two things to note when using this app:
+- The second part of the test states that a message's author's email should be shown when the user hovers their mouse over a message. However, this code is for an iOS app, which has no concept of a mouse! So I've had to improvise, and I've used React Native's touch API instead. So instead of hovering over a message to see the email, simply touch on the message (either with a mouse click if it's on the simulator, or with a finger if it's on an iPhone) instead, and you'll see the email appear.
 
-# NowTV React Interview
+- The original `members.json` data uses avatar images from `http://dummyimage.com`, but `dummyimage.com` now redirects all requests made using `http://` to the `https://` protocol scheme. Not sure if it's part of the test to debug this, but the code I've written here replaces `http://dummyimage.com/...` with `https://dummyimage.com/...` to successfully render the avatar. It does this in a memoized selector, so it's only done once.
+
+
+# (ORIGINAL README:) NowTV React Interview
 
 ![NowTV](./logo.png)
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import {
   FlatList,
+  Image,
   StyleSheet,
   Text,
   TouchableWithoutFeedback,
@@ -25,16 +26,21 @@ class MyListItem extends React.PureComponent {
     const { item } = this.props;
     const { showEmail } = this.state;
     
+    const avatar = item && item.member && item.member.avatar;
+
     return (
       <TouchableWithoutFeedback 
         onPressIn={() => this.changeShowEmailState(true)}
         onPressOut={() => this.changeShowEmailState(false)}
       >
-        <View>
-          <Text style={styles.welcome}>
-            { item.messageBody.message }
-          </Text>
-          { showEmail && <Text style={styles.email}>{item && item.member && item.member.email}</Text> }
+        <View style={styles.listItem}>
+          <Image style={{width: 100, height: 100}} source={{ uri: avatar }}/>
+          <View>
+            <Text style={styles.welcome}>
+              { item.messageBody.message }
+            </Text>
+            { showEmail && <Text style={styles.email}>{item && item.member && item.member.email}</Text> }
+          </View>
         </View>
       </TouchableWithoutFeedback>
     );
@@ -56,7 +62,7 @@ class App extends Component {
   );
 
   render() {
-    const { members, messages } = this.props;
+    const { messages } = this.props;
     
     return (
       <View style={styles.container}>
@@ -94,12 +100,18 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
     backgroundColor: '#F5FCFF',
   },
+  listItem: {
+    display: 'flex',
+    flexDirection: 'row',
+    marginBottom: 10
+  },
   welcome: {
-    fontSize: 20,
+    fontSize: 10,
     textAlign: 'left',
     margin: 10,
   },
   email: {
-    fontSize: 12
+    fontSize: 8,
+    marginLeft: 10
   }
 });

--- a/src/mocks/mockMembers.js
+++ b/src/mocks/mockMembers.js
@@ -1,3 +1,4 @@
 export const members = [{
-    id: 'fe27b760-a915-475c-80bb-7cdf14cc6ef3'
+    id: 'fe27b760-a915-475c-80bb-7cdf14cc6ef3',
+    avatar: 'https://dummyimage.com/100x100.jpg/ffff'
 }];

--- a/src/state/memberMessages/memberMessages.selectors.js
+++ b/src/state/memberMessages/memberMessages.selectors.js
@@ -1,4 +1,0 @@
-import { createSelector } from 'reselect';
-import { selectMembers } from '../members/members.selectors';
-import { selectMessages } from '../messages/messages.selectors';
-

--- a/src/state/messages/messages.selectors.js
+++ b/src/state/messages/messages.selectors.js
@@ -8,12 +8,24 @@ export const getMessageById = id => createSelector(
     messages => messages.find(message => message.id === id)
 );
 
+// Rich messages are messages with their corresponding member details added. It's not remotely efficient,
+// but it's quick to write, does the job, and reselect's memoization minimizes the performance hit
 export const getRichMessages = createSelector([
     selectMembers,
     selectMessages
 ], (members, messages) => messages.map(message => {
+    const DEFAULT_AVATAR = 'https://dummyimage.com/100x100.jpg';
     const member = members.find(member => member.id === message.userId);
-    return Object.assign({}, { messageBody: message }, { member });
+
+    if(!member.avatar) {
+        member.avatar = DEFAULT_AVATAR;
+    }
+    //Ensure avatar's uri contains the 'https' protocol scheme, as dummyimage.com has now switched to https
+    if(!member.avatar.includes('https')) {
+        const regex = /http/gi;
+        member.avatar = member.avatar.replace(regex, 'https');
+    }
+
+    return  Object.assign({}, { messageBody: message }, { member });
 }));
     
-

--- a/src/state/messages/messages.selectors.test.js
+++ b/src/state/messages/messages.selectors.test.js
@@ -24,7 +24,8 @@ describe('messages selectors', () => {
         it('should return a rich message object', () => {
             expect(selectors.getRichMessages.resultFunc(members, messages)).toEqual([
                 Object.assign({}, { messageBody: messages[0] }, { member: {
-                    id: 'fe27b760-a915-475c-80bb-7cdf14cc6ef3'
+                    id: 'fe27b760-a915-475c-80bb-7cdf14cc6ef3',
+                    avatar: 'https://dummyimage.com/100x100.jpg/ffff'
                 } })
             ]);
         })


### PR DESCRIPTION
Renders the member's avatar next to their message.

Note: the `members.json` data uses avatar images from `http://dummyimage.com`, but this website now redirects all requests to `http://` to `https://`. Not sure if it's part of the test to debug this, but the code submitted replaces `http://dummyimage.com/...` with `https://dummyimage.com/...` to successfully render the avatar.